### PR TITLE
fix: use BASE_URL for worker.js path to support GitHub Pages

### DIFF
--- a/src/hooks/useCodeRunner.tsx
+++ b/src/hooks/useCodeRunner.tsx
@@ -9,7 +9,7 @@ export const useCodeRunner = () => {
 
   // init worker and start listening to messages
   useEffect(() => {
-    const worker = new Worker("/worker.js");
+    const worker = new Worker(`${import.meta.env.BASE_URL}worker.js`);
     workerRef.current = worker;
 
     worker.onmessage = (e) => {


### PR DESCRIPTION
Deployed to GitHub Pages and tested. WebAssembly and Python code execution via Pyodide worker are now working as expected.

### What changed:

Updated the worker initialization in [`src/hooks/useCodeRunner.tsx`](diffhunk://#diff-b37d903a43a2dbebba97bc8480ec382d069eb4f29f262d81da3a5b014a64df4cL12-R12) to use `import.meta.env.BASE_URL` for correct worker.js path in both local development and GitHub Pages

Fixes #8